### PR TITLE
Engine improvements (Easier stopping, engine heater tank replacements, fixed duplicate engines)

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -124,20 +124,20 @@ PROTECT_ROLES_FROM_ANTAGONIST
 #ENFORCE_HUMAN_AUTHORITY_ON_EVERYONE
 
 ## If late-joining players have a chance to become a traitor/changeling
-ALLOW_LATEJOIN_ANTAGONISTS
+# ALLOW_LATEJOIN_ANTAGONISTS
 
 ## Uncomment to prevent the nuclear operative leader from getting the war declaration item
 #DISABLE_WAROPS
 
 ## Uncomment to enable dynamic ruleset config file.
-DYNAMIC_CONFIG_ENABLED
+# DYNAMIC_CONFIG_ENABLED
 
 ## RANDOM EVENTS ###
 ## Comment this out to disable random events during the round.
 # ALLOW_RANDOM_EVENTS
 
 ## Uncomment this to disable station traits.
-#FORBID_STATION_TRAITS
+FORBID_STATION_TRAITS
 
 ## Multiplier for earliest start time of dangerous events.
 ## Set to 0 to make dangerous events avaliable from round start.
@@ -456,7 +456,7 @@ ARRIVALS_SHUTTLE_DOCK_WINDOW 55
 
 ## How many wirechewing rodents you want to spawn on exposed maintenane wires at the start of the round. You may wish to set this to 0 if you're testing powernets.
 
-MICE_ROUNDSTART 10
+MICE_ROUNDSTART 1
 
 ## If the percentage of players alive (doesn't count conversions) drops below this threshold the emergency shuttle will be forcefully called (provided it can be)
 #EMERGENCY_SHUTTLE_AUTOCALL_THRESHOLD 0.2
@@ -484,7 +484,7 @@ SHIFT_TIME_START_HOUR 7
 MONKEYCAP 64
 
 ## A cap on how many mice can be bred via cheese wedges
-RATCAP 64
+RATCAP 20
 
 ## Maximum fine for a citation
 MAXFINE 2000

--- a/voidcrew/modules/overmap/code/modules/overmap/ship.dm
+++ b/voidcrew/modules/overmap/code/modules/overmap/ship.dm
@@ -699,28 +699,31 @@
  * * n_dir - The direction to move in
  */
 /obj/structure/overmap/ship/proc/burn_engines(n_dir = null, percentage = 100)
-	// if(!n_dir)
-	// 	decelerate(acceleration_speed * (percentage / 100))
-	// else
-	// 	accelerate(n_dir, acceleration_speed * (percentage / 100))
 	if(state != OVERMAP_SHIP_FLYING)
 		return
 
+	// Decelerate without using fuel
+	if(!n_dir) {
+		decelerate(acceleration_speed * (percentage / 100))
+		return
+	}
+
 	var/thrust_used = 0 //The amount of thrust that the engines will provide with one burn
 	refresh_engines()
+
 	if(!mass)
 		calculate_mass()
 	calculate_avg_fuel()
+
 	for(var/obj/machinery/power/shuttle_engine/ship/E in shuttle.engine_list)
 		if(!E.enabled || E.thruster_active == 0)
 			continue
 		thrust_used += E.burn_engine(percentage)
 	est_thrust = thrust_used //cheeky way of rechecking the thrust, check it every time it's used
 	thrust_used = thrust_used / max(mass * 100, 1) //do not know why this minimum check is here, but I clearly ran into an issue here before
+
 	if(n_dir)
 		accelerate(n_dir, thrust_used)
-	else
-		decelerate(thrust_used)
 
 #undef SHIP_SIZE_THRESHOLD
 

--- a/voidcrew/modules/shuttle/engine/shuttle_engine.dm
+++ b/voidcrew/modules/shuttle/engine/shuttle_engine.dm
@@ -1,3 +1,19 @@
+/obj/machinery/power/shuttle_engine/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
+	// . = ..()
+	if(!port)
+		return FALSE
+	connected_ship_ref = WEAKREF(port)
+	var/found_engine_in_list = FALSE
+	for (var/current_engine in port.engine_list)
+		if (src == current_engine)
+			found_engine_in_list = TRUE
+			return
+	if (found_engine_in_list == FALSE)
+		port.engine_list += src
+	port.current_engine_power += engine_power
+	if(mapload)
+		port.initial_engine_power += engine_power
+
 /**
   * ## Engine Thrusters
   * The workhorse of any movable ship, these engines (usually) take in some kind fuel and produce thrust to move ships.

--- a/voidcrew/modules/shuttle/engine/shuttle_engine.dm
+++ b/voidcrew/modules/shuttle/engine/shuttle_engine.dm
@@ -1,15 +1,18 @@
 /obj/machinery/power/shuttle_engine/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
-	// . = ..()
 	if(!port)
 		return FALSE
 	connected_ship_ref = WEAKREF(port)
 	var/found_engine_in_list = FALSE
+
+	///Shitty deduplicate workaround, only add the engine if it isn't already in the list
+	///I couldn't figure out why this was getting called multiple times, but when I do I will fix it there instead
 	for (var/current_engine in port.engine_list)
 		if (src == current_engine)
 			found_engine_in_list = TRUE
 			return
 	if (found_engine_in_list == FALSE)
 		port.engine_list += src
+
 	port.current_engine_power += engine_power
 	if(mapload)
 		port.initial_engine_power += engine_power

--- a/voidcrew/modules/shuttle/engine/shuttle_heater.dm
+++ b/voidcrew/modules/shuttle/engine/shuttle_heater.dm
@@ -155,14 +155,6 @@
 			fuel_tank = null
 		user.transferItemToLoc(I, src)
 		fuel_tank = I
-		// if (fuel_tank == null)
-		// 	user.transferItemToLoc(I, src)
-		// 	fuel_tank = I
-		// 	balloon_alert(user, "tank inserted")
-		// else
-		// 	user.put_in_hands(fuel_tank)
-		// 	user.transferItemToLoc(I, src)
-		// 	balloon_alert(user, "tank replaced")
 	else
 		return ..()
 

--- a/voidcrew/modules/shuttle/engine/shuttle_heater.dm
+++ b/voidcrew/modules/shuttle/engine/shuttle_heater.dm
@@ -150,9 +150,21 @@
 	if(default_deconstruction_crowbar(I))
 		return
 	if(istype(I, /obj/item/tank/internals))
+		if (fuel_tank)
+			try_put_in_hand(fuel_tank, user)
+			fuel_tank = null
 		user.transferItemToLoc(I, src)
 		fuel_tank = I
-	return ..()
+		// if (fuel_tank == null)
+		// 	user.transferItemToLoc(I, src)
+		// 	fuel_tank = I
+		// 	balloon_alert(user, "tank inserted")
+		// else
+		// 	user.put_in_hands(fuel_tank)
+		// 	user.transferItemToLoc(I, src)
+		// 	balloon_alert(user, "tank replaced")
+	else
+		return ..()
 
 /obj/machinery/atmospherics/components/unary/shuttle/heater/click_alt(mob/living/L)
 	. = ..()


### PR DESCRIPTION
- Fixes duplicate engines in a bad way
- Minor config changes
- Allows you to replace the internal tank in a engine heater
- Changes shuttle stopping functionality
  - Stopping is now free (no fuel usage)
  - Stopping is now instant
  - If you want to "slow down", just click in the opposite direction as before